### PR TITLE
Fixes CSSLint "exclude is not a valid option" error when running tests.

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,2 +1,2 @@
 --ignore=adjoining-classes,box-sizing,compatible-vendor-prefixes,important
---exclude=bower_components/
+--exclude-list=bower_components/


### PR DESCRIPTION
Not sure when this changed on CSSLint but the CLI option is `exclude-list` now. This was causing me an error (on Windows) when running the tests.
