### PR TITLE
Removed Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-install:
-	npm install
-	./node_modules/component/bin/component install --dev
-
-test:
-	npm test
-	./node_modules/component/bin/component build --dev
-
-.PHONY: install

--- a/README.md
+++ b/README.md
@@ -73,20 +73,18 @@ This is an example of an idiomatic SUIT CSS test file:
 
 ## Testing
 
-Install [Node](http://nodejs.org) (comes with npm). It's recommended that you
-also globally install [Component(1)](http://component.io): `npm install -g
-component`.
+Install [Node](http://nodejs.org) (comes with npm).
 
 From the repo root, install the project's development dependencies:
 
 ```
-make
+npm run build-install
 ```
 
 To run the CSS Lint tests and build the front-end development bundle:
 
 ```
-make test
+npm run build-test
 ```
 
 Basic visual tests are in `test.html`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "csslint": ">=0.9.10"
   },
   "scripts": {
-    "test": "./node_modules/.bin/csslint *.css"
+    "build-install": "npm install && component install --dev",
+    "build-test": "csslint test.css && component build --dev"
   }
 }


### PR DESCRIPTION
I moved the functionality to the `scripts` part of `package.json` and updated the `README` accordingly.

This has the additional benefit of:
- Working on Windows without having to have Cygwin installed.
- Not having to have `component` installed globally.

If you're OK with the change I can go ahead and send pull requests with the same change on the other [suitcss](https://github.com/suitcss) repositories that could benefit from it.
